### PR TITLE
XSS fixed in params[:sender].

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -47,7 +47,8 @@ class Receive < Goliath::API
   def response(env)
     channel = env["REQUEST_PATH"][1..-1]
     message = Rack::Utils.escape_html(params["message"])
-    @@redis.publish(channel, {sender: params["sender"], message: message}.to_json)
+    sender = Rack::Utils.escape_html(params["sender"])
+    @@redis.publish(channel, {sender: sender, message: message}.to_json)
     [ 200, { }, [ ] ]
   end
 end


### PR DESCRIPTION
Sender parameter wasn't secured as message. So it was able to insert JS code in sender name and suffer.
